### PR TITLE
Don't check for subgroups.checked in setFilter.  It appears setFilter…

### DIFF
--- a/RLMGroupMemberList.ascx.cs
+++ b/RLMGroupMemberList.ascx.cs
@@ -319,11 +319,10 @@ namespace com.reallifeministries
                 var groups = new List<Group>();
                 groups.Add( _group );
 
-                if (tglSubGroups.Checked)
-                {
-                    var descendedGroups = groupService.GetAllDescendents( _group.Id ).ToList();
-                    groups.AddRange(descendedGroups);
-                }
+                
+                var descendedGroups = groupService.GetAllDescendents( _group.Id ).ToList();
+                groups.AddRange(descendedGroups);
+              
 
                 GroupMemberService gmserv = new GroupMemberService( rockContext );
                 var groupIds = groups.Select( a => a.Id ).ToList();


### PR DESCRIPTION
… is cached, and doesn't get called again.

https://trello.com/c/YxzyB8HP/62-group-roles-not-on-filter

@Kronos11 after merging these updates, you also need to update the sub-module reference in the parent project.
